### PR TITLE
Update CI to run on Ubuntu noble

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: ubuntu:eoan
+      - image: ubuntu:noble
     steps:
       - run:
           name: Use AWS Ubuntu mirror

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     container:
-      image: ubuntu:eoan
+      image: ubuntu:noble
     steps:
       - name: Accept EULAs
         env:

--- a/windows.Dockerfile
+++ b/windows.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:noble
 
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
 


### PR DESCRIPTION
Windows builds are [failing](https://github.com/clementine-player/Clementine/actions/runs/24505845818/job/71644579630?pr=7438) after vendoring an update to projectM, which requires newer CMake. This PR updates the base images to Ubuntu Noble 24.04, which should fix the issue.